### PR TITLE
retrying the linter with a more specific path

### DIFF
--- a/.github/workflows/pr_to_master.yml
+++ b/.github/workflows/pr_to_master.yml
@@ -20,3 +20,4 @@ jobs:
       - uses: jpetrucciani/black-check@master
         with:
           path: '.'
+          path: "importer/"

--- a/importer/main.py
+++ b/importer/main.py
@@ -8,15 +8,7 @@ import os
 
 def post(user, password, file_path):
     url = "http://localhost:8000/geoserver/rest/imports"
-    payload = {
-       "import": {
-          "targetWorkspace": {
-             "workspace": {
-            "name": "enermaps"
-             }
-          },
-       }
-    }
+    payload = {"import": {"targetWorkspace": {"workspace": {"name": "enermaps"}}}}
     session = requests.Session()
     session.auth = (user, password)
     resp = session.post(url, json=payload)
@@ -29,15 +21,18 @@ def post(user, password, file_path):
     with open(file_path) as shapefile:
         resp = session.post(url, files={"name": filename, "filedata": shapefile})
         print(resp, resp.text)
-    resp = session.post("http://localhost:8000/geoserver/rest/imports/{!s}".format(import_id))
+    resp = session.post(
+        "http://localhost:8000/geoserver/rest/imports/{!s}".format(import_id)
+    )
     print(resp, resp.text)
-
 
 
 def get_parser():
     """return the cli command parser
     """
-    parser = argparse.ArgumentParser(__name__, description="import a raster into a geoserver")
+    parser = argparse.ArgumentParser(
+        __name__, description="import a raster into a geoserver"
+    )
     parser.add_argument("-u", "--user", default="admin")
     parser.add_argument("shapefile")
     return parser
@@ -48,7 +43,10 @@ def main():
 
     parser = get_parser()
     args = parser.parse_args()
-    post(user=args.user, password=os.environ['GEOSERVER_PASS'], file_path=args.shapefile)
+    post(
+        user=args.user, password=os.environ["GEOSERVER_PASS"], file_path=args.shapefile
+    )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Github action authentication align with the user authentication to that repository, saving us some time in the process. 
The black linter is pretty inintrusive and produces good enough result. 